### PR TITLE
Move toast message to middle

### DIFF
--- a/client/src/hooks/toastHook.js
+++ b/client/src/hooks/toastHook.js
@@ -2,7 +2,7 @@ import { useToast } from '@chakra-ui/react';
 
 const defaultOptions = {
   duration: 4000,
-  position: 'top-right',
+  position: 'top',
   isClosable: true,
 };
 


### PR DESCRIPTION
Since the menu is located on the top right, when you get multiple messages it is impossible to use the menu.

Since the pages refresh at the moment and the realm selection is lost, this is quite "annoying".

So I moved the toasts to the top middle to mitigate that issue.